### PR TITLE
bugfix: correct LUA_JIT_DIR detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OR_EXEC ?= $(shell which openresty)
-LUA_JIT_DIR ?= $(shell ${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*?)/nginx' | grep -Eo '/.*/')luajit
+LUA_JIT_DIR ?= $(shell ${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')luajit
 LUAROCKS_VER ?= $(shell luarocks --version | grep -E -o  "luarocks [0-9]+.")
 LUA_PATH ?= "./lib/?.lua;./deps/lib/lua/5.1/?.lua;./deps/share/lua/5.1/?.lua;;"
 LUA_CPATH ?= "./deps/lib/lua/5.1/?.so;;"


### PR DESCRIPTION
grep doesn't support lazy match by default. To support it, `-P` should
be used instead of `-E`, see:
https://stackoverflow.com/a/5774431

However, we can achieve the same thing without lazy match.
Because OpenResty's not vanilla Nginx, there will be --option after the
executable.