### PR TITLE
doc: min/max length checks for unicode string are supported now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ options detailed previously, but some features are not supported (correctly)
 at this time:
 
 * Empty tables and empty arrays are the same from Lua point of view
-* Unicode strings are considered as a stream of bytes (so length checks might
-  not behave as expected)
 
 
 On the other hand, some extra features are supported:


### PR DESCRIPTION
The support is added by 32e8c1f0a.