### PR TITLE
fix: avoid polluting the given schema

### DIFF
--- a/lib/jsonschema.lua
+++ b/lib/jsonschema.lua
@@ -1149,7 +1149,11 @@ return {
       parse_ipv6 = custom and custom.parse_ipv6 or parse_ipv6
     }
     local name = custom and custom.name
-    return generate_main_validator_ctx(schema, custom):as_func(name, validatorlib, customlib)
+    local ctx = generate_main_validator_ctx(schema, custom):as_func(name, validatorlib, customlib)
+    if type(schema) == "table" then
+      schema.id = nil
+    end
+    return ctx
   end,
   -- debug only
   generate_validator_code = function(schema, custom)

--- a/t/default.lua
+++ b/t/default.lua
@@ -15,6 +15,7 @@ local rule = {
 -- print(code)
 
 local validator = jsonschema.generate_validator(rule)
+assert(rule.id == nil, "fail: schema is polluted")
 
 local conf = {}
 local ok = validator(conf)


### PR DESCRIPTION
When generating the validator, this library will add `id` field in the
schema to store useful data. We should purge it after.