### PR TITLE
fix: endless loop in utf8_len while input is an invalid utf8 string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Linux Get dependencies
-        run: sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
+      - uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: "5.1.5"
 
       - uses: leafo/gh-actions-luarocks@v4
         with:
           luarocksVersion: "3.8.0"
+
+      - name: Linux Get dependencies
+        run: sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
 
       - name: Linux Before install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,12 @@ jobs:
         with:
           submodules: recursive
       - name: Linux Get dependencies
-        run: |
-          sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl lua5.1 liblua5.1-0-dev
-          curl -fsSL https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh | sh
+        run: sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
 
       - name: Linux Before install
+        uses: leafo/gh-actions-luarocks@v4
+        with:
+          luarocksVersion: "3.8.0"
         run: |
           sudo luarocks install luacheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+
       - name: Linux Get dependencies
         run: sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
 
-      - name: Linux Before install
-        uses: leafo/gh-actions-luarocks@v4
+      - uses: leafo/gh-actions-luarocks@v4
         with:
           luarocksVersion: "3.8.0"
+
+      - name: Linux Before install
         run: |
           sudo luarocks install luacheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,18 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: leafo/gh-actions-lua@v8.0.0
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v8.0.0
         with:
           luaVersion: "5.1.5"
 
-      - uses: leafo/gh-actions-luarocks@v4
+      - name: Setup Luarocks
+        uses: leafo/gh-actions-luarocks@v4
         with:
           luarocksVersion: "3.8.0"
 
       - name: Linux Get dependencies
         run: sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
-
-      - name: Linux Before install
-        run: |
-          sudo luarocks install luacheck
 
       - name: Linux Install
         run: |
@@ -43,6 +41,6 @@ jobs:
 
       - name: Linux Script
         run: |
-          sudo luarocks install rockspec/jsonschema-master-0.rockspec
+          luarocks make rockspec/jsonschema-master-0.rockspec
           export PATH=$OPENRESTY_PREFIX/nginx/sbin:$PATH
           make test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 OR_EXEC ?= $(shell which openresty)
 LUA_JIT_DIR ?= $(shell ${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')luajit
 LUAROCKS_VER ?= $(shell luarocks --version | grep -E -o  "luarocks [0-9]+.")
-LUA_PATH ?= "./lib/?.lua;./deps/lib/lua/5.1/?.lua;./deps/share/lua/5.1/?.lua;;"
-LUA_CPATH ?= "./deps/lib/lua/5.1/?.so;;"
+LUA_PATH ?= ./lib/?.lua;./deps/lib/lua/5.1/?.lua;./deps/share/lua/5.1/?.lua;;
+LUA_CPATH ?= ./deps/lib/lua/5.1/?.so;;
 
 
 ### help:         Show Makefile rules.
@@ -27,11 +27,11 @@ endif
 
 ### test:         Run the test case
 test:
-	LUA_PATH=$(LUA_PATH) LUA_CPATH=$(LUA_CPATH) resty t/draft4.lua
-	LUA_PATH=$(LUA_PATH) LUA_CPATH=$(LUA_CPATH) resty t/draft6.lua
-	LUA_PATH=$(LUA_PATH) LUA_CPATH=$(LUA_CPATH) resty t/draft7.lua
-	LUA_PATH=$(LUA_PATH) LUA_CPATH=$(LUA_CPATH) resty t/default.lua
-	LUA_PATH=$(LUA_PATH) LUA_CPATH=$(LUA_CPATH) resty t/200more_variables.lua
+	LUA_PATH="$(LUA_PATH)" LUA_CPATH="$(LUA_CPATH)" resty t/draft4.lua
+	LUA_PATH="$(LUA_PATH)" LUA_CPATH="$(LUA_CPATH)" resty t/draft6.lua
+	LUA_PATH="$(LUA_PATH)" LUA_CPATH="$(LUA_CPATH)" resty t/draft7.lua
+	LUA_PATH="$(LUA_PATH)" LUA_CPATH="$(LUA_CPATH)" resty t/default.lua
+	LUA_PATH="$(LUA_PATH)" LUA_CPATH="$(LUA_CPATH)" resty t/200more_variables.lua
 
 
 ### clean:        Clean the test case

--- a/t/default.lua
+++ b/t/default.lua
@@ -187,3 +187,29 @@ local t = {
 local ok = validator(t)
 assert(ok~=nil, "fail: failed to negative check of int64")
 ngx.say("passed: pass negative check of int64")
+
+----------------------------------------------------- test case 7
+-- check string len
+-- issue #61
+local cases = {
+    {"abcd", 4},
+    {"☺☻☹", 3},
+    {"1,2,3,4", 7},
+    {"\xff", 1},
+    {"\xc2\x80", 1},
+    {"\xe0\x00", 2},
+    {"\xe2\x80a", 3},
+    {"\xed\x80\x80", 1},
+    {"\xf0\x80", 2},
+    {"\xf4\x80", 2},
+}
+
+local schema = {}
+for i, case in ipairs(cases) do
+    schema.minLength = case[2]
+    schema.maxLength = case[2]
+    local validator = jsonschema.generate_validator(schema)
+    local ok, err = validator(case[1])
+    assert(ok, string.format("fail: validate case %d,  err: %s, ", i, err))
+end
+ngx.say("passed: check string len")


### PR DESCRIPTION
This pr references the implementation of the [`utf8.RuneCountInString`](https://github.com/golang/go/blob/master/src/unicode/utf8/utf8.go#L411) in golang, takes invalid utf8 strings in consideration and treats them as single bytes. close #61 