### PR TITLE
feat: Add support of LuaJIT 64bit integer types

### DIFF
--- a/lib/jsonschema.lua
+++ b/lib/jsonschema.lua
@@ -479,8 +479,8 @@ local function typeexpr(ctx, jsontype, datatype, tablekind)
   elseif jsontype == 'table' then
     return sformat(' %s == "table" ', datatype)
   elseif jsontype == 'integer' then
-    return sformat(' (%s == "number" and %s(%s, 1.0) == 0.0) ',
-      datatype, ctx:libfunc('math.fmod'), ctx:param(1))
+    return sformat(' ((%s == "number" or (%s == "cdata" and tonumber(%s) ~= nil)) and %s %% 1.0 == 0.0) ',
+      datatype, datatype, ctx:param(1), ctx:param(1))
   elseif jsontype == 'string' or jsontype == 'boolean' or jsontype == 'number' then
     return sformat('%s == %q', datatype, jsontype)
   elseif jsontype == 'null' then

--- a/t/default.lua
+++ b/t/default.lua
@@ -1,3 +1,4 @@
+local ffi = require('ffi')
 local jsonschema = require 'jsonschema'
 ----------------------------------------------------- test case 1
 local rule = {
@@ -150,3 +151,39 @@ if not ok then
   return
 end
 assert(t.foo == false, "fail: inject default false value")
+
+----------------------------------------------------- test int64
+local rule = {
+  type = "object",
+  properties = {
+      foo = "integer"
+  }
+}
+
+local validator = jsonschema.generate_validator(rule)
+local t = {
+  foo = 1ULL
+}
+local ok, err = validator(t)
+assert(ok, ("fail: failed to check uint64: %s"):format(err))
+ngx.say("passed: pass check uint64")
+
+local t = {
+  foo = -2LL
+}
+local ok, err = validator(t)
+assert(ok, ("fail: failed to check int64: %s"):format(err))
+ngx.say("passed: pass check int64")
+
+---cdata format
+ffi.cdef[[
+  union bar { int i;};
+]]
+
+local t = {
+  foo = ffi.new("union bar", {})
+}
+
+local ok = validator(t)
+assert(ok~=nil, "fail: failed to negative check of int64")
+ngx.say("passed: pass negative check of int64")


### PR DESCRIPTION
LuaJIT has a couple of 64bit integers, such as int64 and uint64. These types are represented as cdata, not numbers. This PR introduces the ability to check these types as jsonschema integer.