### PR TITLE
chore: update luarocks version to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
       - name: Linux Get dependencies
         run: |
-          sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
+          sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl lua5.3
           curl -fsSL https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh | sh
 
       - name: Linux Before install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           submodules: recursive
       - name: Linux Get dependencies
-        run: sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl luarocks
+        run: |
+          sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl
+          curl -fsSL https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh | sh
 
       - name: Linux Before install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
       - name: Linux Get dependencies
         run: |
-          sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl lua5.3
+          sudo apt install -y build-essential libncurses5-dev libreadline-dev libssl-dev perl lua5.1 liblua5.1-0-dev
           curl -fsSL https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh | sh
 
       - name: Linux Before install


### PR DESCRIPTION
We could install luarocks using `linux-install-luarocks.sh`, which is Apache APISIX repository script, so we can maintain a unified version of luarocks with the Apache APISIX repository.

fix https://github.com/api7/jsonschema/issues/69