### PR TITLE
fix(deps): add missing deps `lrexlib-pcre` for rockspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Running the tests:
 The project references the pcre regular library.
 
 If you were using the LuaJIT of OpenResty, it will use the built-in `ngx.re.find` automatically.
-But if you are using Lua 5.2, 5.3 or LuaJIT 2.1 beta, you will need to install `lrexlib-pcre`.
+But if you are using Lua 5.2, 5.3 or LuaJIT 2.1 beta, it will use `lrexlib-pcre` instead.
 
 In addition, the project also relies on the `net_url` library, which you need to install anyway.
 

--- a/rockspec/jsonschema-master-0.rockspec
+++ b/rockspec/jsonschema-master-0.rockspec
@@ -20,6 +20,7 @@ Base on https://github.com/jdesgats/ljsonschema .
 
 dependencies = {
   "net-url",
+  "lrexlib-pcre = 2.9.1-1",
 }
 
 build = {


### PR DESCRIPTION
fix `rex_pcre.so` not found when loading `rex_pcre` module