### PR TITLE
fix: multipleOf float precision with tolerance-based check

### DIFF
--- a/lib/jsonschema.lua
+++ b/lib/jsonschema.lua
@@ -984,9 +984,11 @@ generate_validator = function(ctx, schema)
         -- integer multipleOf: modulo is enough
         ctx:stmt(sformat('  if %s %% %d ~= 0 then', ctx:param(1), mof))
       else
-          -- float multipleOf: it's a bit more hacky and slow
+          -- float multipleOf: use tolerance to handle IEEE 754 precision errors
+          -- e.g. 1.13 / 0.01 = 112.99999999999999 in Lua/LuaJIT
         ctx:stmt(sformat('  local quotient = %s / %s', ctx:param(1), mof))
-        ctx:stmt(sformat('  if %s(quotient) ~= quotient then', ctx:libfunc('math.modf')))
+        ctx:stmt(sformat('  local rounded = %s(quotient + 0.5)', ctx:libfunc('math.floor')))
+        ctx:stmt(sformat('  if %s(quotient - rounded) > 1e-10 then', ctx:libfunc('math.abs')))
       end
       ctx:stmt(sformat(  '    return false, %s("expected %%s to be a multiple of %s", %s)',
                        ctx:libfunc('string.format'), mof, ctx:param(1)))

--- a/lib/jsonschema.lua
+++ b/lib/jsonschema.lua
@@ -984,11 +984,14 @@ generate_validator = function(ctx, schema)
         -- integer multipleOf: modulo is enough
         ctx:stmt(sformat('  if %s %% %d ~= 0 then', ctx:param(1), mof))
       else
-          -- float multipleOf: use tolerance to handle IEEE 754 precision errors
-          -- e.g. 1.13 / 0.01 = 112.99999999999999 in Lua/LuaJIT
+          -- float multipleOf: use relative tolerance to handle IEEE 754
+          -- precision errors. e.g. 1.13 / 0.01 = 112.99999999999999
+          -- We check whether the fractional part of the quotient is
+          -- negligible relative to its magnitude.
         ctx:stmt(sformat('  local quotient = %s / %s', ctx:param(1), mof))
         ctx:stmt(sformat('  local rounded = %s(quotient + 0.5)', ctx:libfunc('math.floor')))
-        ctx:stmt(sformat('  if %s(quotient - rounded) > 1e-10 then', ctx:libfunc('math.abs')))
+        ctx:stmt(        '  local tol = 1e-12 * (rounded == 0 and 1 or (rounded < 0 and -rounded or rounded))')
+        ctx:stmt(sformat('  if %s(quotient - rounded) > tol then', ctx:libfunc('math.abs')))
       end
       ctx:stmt(sformat(  '    return false, %s("expected %%s to be a multiple of %s", %s)',
                        ctx:libfunc('string.format'), mof, ctx:param(1)))

--- a/spec/extra/multipleOf.json
+++ b/spec/extra/multipleOf.json
@@ -51,5 +51,24 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "multipleOf with large values",
+        "schema": {
+            "type": "number",
+            "multipleOf": 1000000000.5
+        },
+        "tests": [
+            {
+                "description": "exact large multiple is valid",
+                "data": 2000000001.0,
+                "valid": true
+            },
+            {
+                "description": "large value offset by 0.05 is invalid",
+                "data": 1000000000.55,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/spec/extra/multipleOf.json
+++ b/spec/extra/multipleOf.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "multipleOf with float precision",
+        "schema": {
+            "type": "number",
+            "multipleOf": 0.01
+        },
+        "tests": [
+            {
+                "description": "1.13 is a multiple of 0.01",
+                "data": 1.13,
+                "valid": true
+            },
+            {
+                "description": "0.01 is a multiple of 0.01",
+                "data": 0.01,
+                "valid": true
+            },
+            {
+                "description": "100.05 is a multiple of 0.01",
+                "data": 100.05,
+                "valid": true
+            },
+            {
+                "description": "1.1312 is not a multiple of 0.01",
+                "data": 1.1312,
+                "valid": false
+            },
+            {
+                "description": "0.015 is not a multiple of 0.01",
+                "data": 0.015,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multipleOf with integer",
+        "schema": {
+            "type": "number",
+            "multipleOf": 3
+        },
+        "tests": [
+            {
+                "description": "9 is a multiple of 3",
+                "data": 9,
+                "valid": true
+            },
+            {
+                "description": "10 is not a multiple of 3",
+                "data": 10,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/t/draft4.lua
+++ b/t/draft4.lua
@@ -47,6 +47,7 @@ local supported = {
   "spec/extra/dependencies.json",
   "spec/extra/table.json",
   "spec/extra/ref.json",
+  "spec/extra/multipleOf.json",
 
   'spec/JSON-Schema-Test-Suite/tests/draft4/type.json',
   'spec/JSON-Schema-Test-Suite/tests/draft4/default.json',

--- a/t/draft7.lua
+++ b/t/draft7.lua
@@ -50,6 +50,7 @@ local supported = {
   "spec/extra/ref.json",
   "spec/extra/format.json",
   "spec/extra/default.json",
+  "spec/extra/multipleOf.json",
 
   'spec/JSON-Schema-Test-Suite/tests/draft7/type.json',
   'spec/JSON-Schema-Test-Suite/tests/draft7/default.json',


### PR DESCRIPTION
The previous check used `math.modf` to verify that the quotient of `value / multipleOf` is an integer. Due to IEEE 754 floating-point precision, this fails for valid cases like `1.13 / 0.01` which yields `112.99999999999999` instead of `113`.

Replaced with a tolerance-based check: round the quotient and verify the difference is within `1e-10`.

Added test cases in `spec/extra/multipleOf.json` covering both valid and invalid float multipleOf scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipleOf validation for floating‑point numbers with enhanced tolerance handling to reduce false negatives on precision-sensitive values.

* **Tests**
  * Added comprehensive multipleOf test suites covering small decimals, large divisors, and integer cases; test harnesses for draft4 and draft7 now include these scenarios to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->