### PR TITLE
fix: don't share datatype across recursive validator calls

### DIFF
--- a/lib/jsonschema.lua
+++ b/lib/jsonschema.lua
@@ -595,9 +595,15 @@ local reg_map = {
 
 generate_validator = function(ctx, schema)
   -- get type informations as they will be necessary anyway
-  local datatype = ctx:localvartab(sformat('%s(%s)',
+  -- These must be real `local`s (not shared table fields) because they hold
+  -- per-call state. Recursive calls into nested schema validators (e.g. via
+  -- `items` or `properties`) would otherwise mutate the outer function's
+  -- `datatype`, leading to wrong-branch execution after the recursion returns
+  -- (e.g. running a string-only check like `maxLength` on a table value and
+  -- crashing inside `utf8_len`).
+  local datatype = ctx:localvar(sformat('%s(%s)',
     ctx:libfunc('type'), ctx:param(1)))
-  local datakind = ctx:localvartab(sformat('%s == "table" and %s(%s)',
+  local datakind = ctx:localvar(sformat('%s == "table" and %s(%s)',
     datatype, ctx:libfunc('lib.tablekind'), ctx:param(1)))
 
   if type(schema) == "table" and schema._org_val ~= nil then

--- a/t/default.lua
+++ b/t/default.lua
@@ -246,6 +246,7 @@ local rule = {
     items = { type = "string" },
 }
 local validator = jsonschema.generate_validator(rule)
-local ok, err = pcall(validator, { "a", "b", "c" })
-assert(ok, "fail: recursive datatype clobber: " .. tostring(err))
+local pcall_ok, valid, val_err = pcall(validator, { "a", "b", "c" })
+assert(pcall_ok, "fail: validator threw an error: " .. tostring(valid))
+assert(valid, "fail: validator returned false: " .. tostring(val_err))
 ngx.say("passed: recursive datatype is not shared across calls")

--- a/t/default.lua
+++ b/t/default.lua
@@ -233,3 +233,19 @@ local t = {
 local ok, err = validator(t)
 assert(ok~=nil, ("pattern: failed to check pattern with `%%`: %s"):format(err))
 ngx.say("passed: pass check pattern with `%`")
+
+----------------------------------------------------- test case 9
+-- regression: per-call `datatype` must not be shared across recursive calls.
+-- Schemas like `{type=array, maxLength=N, items={type=string}}` used to crash
+-- because the items recursion mutated the outer function's datatype variable,
+-- causing the outer string-only `maxLength` check to run on the array value
+-- and call `utf8_len` on a table.
+local rule = {
+    type = "array",
+    maxLength = 10,
+    items = { type = "string" },
+}
+local validator = jsonschema.generate_validator(rule)
+local ok, err = pcall(validator, { "a", "b", "c" })
+assert(ok, "fail: recursive datatype clobber: " .. tostring(err))
+ngx.say("passed: recursive datatype is not shared across calls")


### PR DESCRIPTION
## What

The codegen stored each generated function's per-call `datatype` / `datakind` variables as fields on a shared `locals` table (introduced by #41 to dodge LuaJIT's 200-local limit). Because every generated schema validator is its own Lua function, recursing into a nested validator (e.g. via `items` or `properties`) overwrote the outer function's datatype with the inner value's type. After the recursion returned, the outer function would take the wrong branch.

## Concrete crash

```lua
local jsonschema = require 'jsonschema'
local v = jsonschema.generate_validator({
  type = 'array', maxLength = 10, items = { type = 'string' }
})
v({ 'a', 'b' })
-- jsonschema.lua:386: bad argument #1 to 'str_byte' (string expected, got table)
```

The outer validator looped over string items (each call set `datatype = 'string'` on the shared `locals` table), and after the loop returned, `if datatype == 'string' then` was true, so the string-only `maxLength` branch ran on the array and called `utf8_len` on a table.

## Fix

Use real `local` slots for `datatype` / `datakind`. Each generated validator function has its own 200-local budget, so the original LuaJIT workaround from #41 is unnecessary for these per-call vars. `localvartab` is still used for the cross-function validator forward declarations and the propset cache where shared storage is intentional.

## Tests

- Added a regression test in `t/default.lua` (test case 9).
- All existing tests still pass, including `t/200more_variables.lua` which guards #41's original concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validator recursion that could cause outer-type checks to run with incorrect state, preventing crashes when validating nested array/string schemas.

* **Tests**
  * Added a regression test ensuring nested schema validation no longer shares per-call state and validates safely in recursive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->